### PR TITLE
Texture engine was not being initialized properly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,13 +92,14 @@ function Game(opts) {
   this.pendingChunks = []
   
   if (process.browser) {
-    this.materials = this.texture_module(this, {
+    this.materials = this.texture_module({
       useAtlas: (opts.useAtlas === undefined) ? false : opts.useAtlas,
       texturePath: opts.texturePath || './textures/',
       artPacks: opts.artPacks,
       materialType: opts.materialType || THREE.MeshLambertMaterial,
       materialParams: opts.materialParams || {},
-      materialFlatColor: opts.materialFlatColor === true
+      materialFlatColor: opts.materialFlatColor === true,
+      game: this
     })
     if (opts.appendDocument) this.appendTo(document.body)
     if (opts.exposeGlobal) window.game = window.g = this


### PR DESCRIPTION
Changes to the constructor for voxel-texture were reverted to no longer take (game,opt), it just takes (opt).  This caused initialization failure in voxpopuli because voxel-texture tries to get game.THREE and game.ao, but there was no game member on the opts object (in fact, the opts object was game itself and so it was completely broken) because voxel-engine was still using the non-reverted interface.
